### PR TITLE
[named] provides an identifier for each instrumented client

### DIFF
--- a/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClients.java
+++ b/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClients.java
@@ -22,18 +22,25 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /** Factor methods for creating an instrumented {@code OkHttpClient}. */
 public final class InstrumentedOkHttpClients {
+
   /** Create an instrumented {@code OkHttpClient}. */
   public static OkHttpClient create(MetricRegistry registry) {
     final OkHttpClient client = new OkHttpClient();
     client.setConnectTimeout(10, SECONDS);
     client.setReadTimeout(10, SECONDS);
     client.setWriteTimeout(10, SECONDS);
-    return new InstrumentedOkHttpClient(registry, client);
+    return new InstrumentedOkHttpClient(registry, "default-client", client);
   }
 
-  /** Create an instrumented {@code OkHttpClient}, using the given client. */
-  public static OkHttpClient create(MetricRegistry registry, OkHttpClient client) {
-    return new InstrumentedOkHttpClient(registry, client);
+  /**
+   * Create an instrumented {@code OkHttpClient}, using the given client.
+   *
+   * <p>{@code name} provides an identifier for the instrumented client.  This
+   * is useful in situations where you have more than one instrumented client
+   * in your application.</p>
+   */
+  public static OkHttpClient create(MetricRegistry registry, String name, OkHttpClient client) {
+    return new InstrumentedOkHttpClient(registry, name, client);
   }
 
   private InstrumentedOkHttpClients() {

--- a/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientsTest.java
+++ b/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientsTest.java
@@ -46,7 +46,7 @@ public final class InstrumentedOkHttpClientsTest {
 
   @Test public void createWithClient() throws Exception {
     OkHttpClient rawClient = new OkHttpClient();
-    OkHttpClient client = InstrumentedOkHttpClients.create(registry, rawClient);
+    OkHttpClient client = InstrumentedOkHttpClients.create(registry, "service-name", rawClient);
 
     assertThat(client.getDispatcher()).isEqualTo(rawClient.getDispatcher());
     assertThat(client.getProxy()).isEqualTo(rawClient.getProxy());


### PR DESCRIPTION
This is a suggestion for providing easily identifiable metrics for individual clients.

Lets you provide an identifier for each instrumented client.
This is very useful when looking at metrics in applications that consume
services from many other services and lets you see which service a client is using.

Adresses #22.