### PR TITLE
No custom name by default

### DIFF
--- a/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClient.java
+++ b/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClient.java
@@ -50,7 +50,7 @@ final class InstrumentedOkHttpClient extends OkHttpClient {
   private final OkHttpClient rawClient;
   private final String name;
 
-  public InstrumentedOkHttpClient(MetricRegistry registry, String name, final OkHttpClient rawClient) {
+  InstrumentedOkHttpClient(MetricRegistry registry, OkHttpClient rawClient, String name) {
     this.rawClient = rawClient;
     this.registry = registry;
     this.name = name;
@@ -64,36 +64,36 @@ final class InstrumentedOkHttpClient extends OkHttpClient {
    *
    * <p>The generated identifier is the fully qualified name of the
    * {@link OkHttpClient}, plus the {@link InstrumentedOkHttpClient#name} of
-   * this is client, plus the given {@code fieldName}.</p>
+   * this is client, plus the given {@code metric}.
    */
-  String registryName(String fieldName) {
-    return name(OkHttpClient.class, name, fieldName);
+  String metricId(String metric) {
+    return name(OkHttpClient.class, name, metric);
   }
 
   private void instrumentHttpCache() {
     if (getCache() == null) return;
 
-    registry.register(registryName("cache-request-count"), new Gauge<Integer>() {
+    registry.register(metricId("cache-request-count"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getCache().getRequestCount();  // The number of HTTP requests issued since this cache was created.
       }
     });
-    registry.register(registryName("cache-hit-count"), new Gauge<Integer>() {
+    registry.register(metricId("cache-hit-count"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getCache().getHitCount();  // ... the number of those requests that required network use.
       }
     });
-    registry.register(registryName("cache-network-count"), new Gauge<Integer>() {
+    registry.register(metricId("cache-network-count"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getCache().getNetworkCount();  // ... the number of those requests whose responses were served by the cache.
       }
     });
-    registry.register(registryName("cache-write-success-count"), new Gauge<Integer>() {
+    registry.register(metricId("cache-write-success-count"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getCache().getWriteSuccessCount();
       }
     });
-    registry.register(registryName("cache-write-abort-count"), new Gauge<Integer>() {
+    registry.register(metricId("cache-write-abort-count"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getCache().getWriteAbortCount();
       }
@@ -113,9 +113,9 @@ final class InstrumentedOkHttpClient extends OkHttpClient {
         return rawClient.getCache().getMaxSize();
       }
     };
-    registry.register(registryName("cache-current-size"), currentCacheSize);
-    registry.register(registryName("cache-max-size"), maxCacheSize);
-    registry.register(registryName("cache-size"), new RatioGauge() {
+    registry.register(metricId("cache-current-size"), currentCacheSize);
+    registry.register(metricId("cache-max-size"), maxCacheSize);
+    registry.register(metricId("cache-size"), new RatioGauge() {
       @Override protected Ratio getRatio() {
         return Ratio.of(currentCacheSize.getValue(), maxCacheSize.getValue());
       }
@@ -125,17 +125,17 @@ final class InstrumentedOkHttpClient extends OkHttpClient {
   private void instrumentConnectionPool() {
     if (getConnectionPool() == null) rawClient.setConnectionPool(ConnectionPool.getDefault());
 
-    registry.register(registryName("connection-pool-count"), new Gauge<Integer>() {
+    registry.register(metricId("connection-pool-count"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getConnectionPool().getConnectionCount();
       }
     });
-    registry.register(registryName("connection-pool-count-http"), new Gauge<Integer>() {
+    registry.register(metricId("connection-pool-count-http"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getConnectionPool().getHttpConnectionCount();
       }
     });
-    registry.register(registryName("connection-pool-count-multiplexed"), new Gauge<Integer>() {
+    registry.register(metricId("connection-pool-count-multiplexed"), new Gauge<Integer>() {
       @Override public Integer getValue() {
         return rawClient.getConnectionPool().getMultiplexedConnectionCount();
       }

--- a/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClients.java
+++ b/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClients.java
@@ -29,18 +29,40 @@ public final class InstrumentedOkHttpClients {
     client.setConnectTimeout(10, SECONDS);
     client.setReadTimeout(10, SECONDS);
     client.setWriteTimeout(10, SECONDS);
-    return new InstrumentedOkHttpClient(registry, "default-client", client);
+    return new InstrumentedOkHttpClient(registry, client, null);
+  }
+
+  /** Create an instrumented {@code OkHttpClient} using the given client. */
+  public static OkHttpClient create(MetricRegistry registry, OkHttpClient client) {
+    return new InstrumentedOkHttpClient(registry, client, null);
   }
 
   /**
-   * Create an instrumented {@code OkHttpClient}, using the given client.
+   * Create an instrumented {@code OkHttpClient} and give it the provided
+   * {@code name}.
    *
    * <p>{@code name} provides an identifier for the instrumented client.  This
    * is useful in situations where you have more than one instrumented client
-   * in your application.</p>
+   * in your application.
    */
-  public static OkHttpClient create(MetricRegistry registry, String name, OkHttpClient client) {
-    return new InstrumentedOkHttpClient(registry, name, client);
+  public static OkHttpClient create(MetricRegistry registry, String name) {
+    final OkHttpClient client = new OkHttpClient();
+    client.setConnectTimeout(10, SECONDS);
+    client.setReadTimeout(10, SECONDS);
+    client.setWriteTimeout(10, SECONDS);
+    return new InstrumentedOkHttpClient(registry, client, name);
+  }
+
+  /**
+   * Create an instrumented {@code OkHttpClient} using the given client and
+   * give it the provided name.
+   *
+   * <p>{@code name} provides an identifier for the instrumented client.  This
+   * is useful in situations where you have more than one instrumented client
+   * in your application.
+   */
+  public static OkHttpClient create(MetricRegistry registry, OkHttpClient client, String name) {
+    return new InstrumentedOkHttpClient(registry, client, name);
   }
 
   private InstrumentedOkHttpClients() {

--- a/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientTest.java
+++ b/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientTest.java
@@ -71,14 +71,14 @@ public final class InstrumentedOkHttpClientTest {
 
     Cache cache = new Cache(cacheRule.getRoot(), Long.MAX_VALUE);
     rawClient.setCache(cache);
-    OkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
+    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
 
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".cache-max-size")
+        .get(client.metricId("cache-max-size"))
         .getValue())
         .isEqualTo(Long.MAX_VALUE);
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".cache-current-size")
+        .get(client.metricId("cache-current-size"))
         .getValue())
         .isEqualTo(0L);
 
@@ -86,7 +86,7 @@ public final class InstrumentedOkHttpClientTest {
     Response response = client.newCall(request).execute();
 
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".cache-current-size")
+        .get(client.metricId("cache-current-size"))
         .getValue())
         .isEqualTo(rawClient.getCache().getSize());
 
@@ -103,18 +103,18 @@ public final class InstrumentedOkHttpClientTest {
     URL baseUrl = server.getUrl("/");
 
     rawClient.setConnectionPool(ConnectionPool.getDefault());
-    OkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
+    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
 
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".connection-pool-count")
+        .get(client.metricId("connection-pool-count"))
         .getValue())
         .isEqualTo(0);
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".connection-pool-count-http")
+        .get(client.metricId("connection-pool-count-http"))
         .getValue())
         .isEqualTo(0);
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".connection-pool-count-multiplexed")
+        .get(client.metricId("connection-pool-count-multiplexed"))
         .getValue())
         .isEqualTo(0);
 
@@ -124,15 +124,15 @@ public final class InstrumentedOkHttpClientTest {
     Response resp2 = client.newCall(req2).execute();
 
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".connection-pool-count")
+        .get(client.metricId("connection-pool-count"))
         .getValue())
         .isEqualTo(1);
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".connection-pool-count-http")
+        .get(client.metricId("connection-pool-count-http"))
         .getValue())
         .isEqualTo(1);
     assertThat(registry.getGauges()
-        .get(OkHttpClient.class.getName() + ".connection-pool-count-multiplexed")
+        .get(client.metricId("connection-pool-count-multiplexed"))
         .getValue())
         .isEqualTo(0);
 
@@ -150,14 +150,14 @@ public final class InstrumentedOkHttpClientTest {
 
     rawClient.setDispatcher(new Dispatcher(MoreExecutors.newDirectExecutorService()));  // Force the requests to execute on this unit tests thread.
     rawClient.setConnectionPool(ConnectionPool.getDefault());
-    OkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
+    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
 
     assertThat(registry.getMeters()
-        .get(OkHttpClient.class.getName() + ".network-requests-submitted")
+        .get(client.metricId("network-requests-submitted"))
         .getCount())
         .isEqualTo(0);
     assertThat(registry.getMeters()
-        .get(OkHttpClient.class.getName() + ".network-requests-completed")
+        .get(client.metricId("network-requests-completed"))
         .getCount())
         .isEqualTo(0);
 
@@ -167,11 +167,11 @@ public final class InstrumentedOkHttpClientTest {
     client.newCall(req2).enqueue(new TestCallback());
 
     assertThat(registry.getMeters()
-        .get(OkHttpClient.class.getName() + ".network-requests-submitted")
+        .get(client.metricId("network-requests-submitted"))
         .getCount())
         .isEqualTo(2);
     assertThat(registry.getMeters()
-        .get(OkHttpClient.class.getName() + ".network-requests-completed")
+        .get(client.metricId("network-requests-completed"))
         .getCount())
         .isEqualTo(2);
   }

--- a/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientTest.java
+++ b/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientTest.java
@@ -34,7 +34,6 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -57,12 +56,6 @@ public final class InstrumentedOkHttpClientTest {
     rawClient = new OkHttpClient();
   }
 
-  @After public void tearDown() throws Exception {
-    mockRegistry = null;
-    registry = null;
-    rawClient = null;
-  }
-
   @Rule public TemporaryFolder cacheRule = new TemporaryFolder();
 
   @Test public void httpCacheIsInstrumented() throws Exception {
@@ -78,16 +71,14 @@ public final class InstrumentedOkHttpClientTest {
 
     Cache cache = new Cache(cacheRule.getRoot(), Long.MAX_VALUE);
     rawClient.setCache(cache);
-    OkHttpClient client = InstrumentedOkHttpClients.create(registry, "service-name", rawClient);
-
-    String baseName = OkHttpClient.class.getName() + ".service-name";
+    OkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
 
     assertThat(registry.getGauges()
-        .get(baseName + ".cache-max-size")
+        .get(OkHttpClient.class.getName() + ".cache-max-size")
         .getValue())
         .isEqualTo(Long.MAX_VALUE);
     assertThat(registry.getGauges()
-        .get(baseName + ".cache-current-size")
+        .get(OkHttpClient.class.getName() + ".cache-current-size")
         .getValue())
         .isEqualTo(0L);
 
@@ -95,7 +86,7 @@ public final class InstrumentedOkHttpClientTest {
     Response response = client.newCall(request).execute();
 
     assertThat(registry.getGauges()
-        .get(baseName + ".cache-current-size")
+        .get(OkHttpClient.class.getName() + ".cache-current-size")
         .getValue())
         .isEqualTo(rawClient.getCache().getSize());
 
@@ -112,20 +103,18 @@ public final class InstrumentedOkHttpClientTest {
     URL baseUrl = server.getUrl("/");
 
     rawClient.setConnectionPool(ConnectionPool.getDefault());
-    OkHttpClient client = InstrumentedOkHttpClients.create(registry, "service-name", rawClient);
-
-    String baseName = OkHttpClient.class.getName() + ".service-name";
+    OkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
 
     assertThat(registry.getGauges()
-        .get(baseName + ".connection-pool-count")
+        .get(OkHttpClient.class.getName() + ".connection-pool-count")
         .getValue())
         .isEqualTo(0);
     assertThat(registry.getGauges()
-        .get(baseName + ".connection-pool-count-http")
+        .get(OkHttpClient.class.getName() + ".connection-pool-count-http")
         .getValue())
         .isEqualTo(0);
     assertThat(registry.getGauges()
-        .get(baseName + ".connection-pool-count-multiplexed")
+        .get(OkHttpClient.class.getName() + ".connection-pool-count-multiplexed")
         .getValue())
         .isEqualTo(0);
 
@@ -135,15 +124,15 @@ public final class InstrumentedOkHttpClientTest {
     Response resp2 = client.newCall(req2).execute();
 
     assertThat(registry.getGauges()
-        .get(baseName + ".connection-pool-count")
+        .get(OkHttpClient.class.getName() + ".connection-pool-count")
         .getValue())
         .isEqualTo(1);
     assertThat(registry.getGauges()
-        .get(baseName + ".connection-pool-count-http")
+        .get(OkHttpClient.class.getName() + ".connection-pool-count-http")
         .getValue())
         .isEqualTo(1);
     assertThat(registry.getGauges()
-        .get(baseName + ".connection-pool-count-multiplexed")
+        .get(OkHttpClient.class.getName() + ".connection-pool-count-multiplexed")
         .getValue())
         .isEqualTo(0);
 
@@ -161,16 +150,14 @@ public final class InstrumentedOkHttpClientTest {
 
     rawClient.setDispatcher(new Dispatcher(MoreExecutors.newDirectExecutorService()));  // Force the requests to execute on this unit tests thread.
     rawClient.setConnectionPool(ConnectionPool.getDefault());
-    OkHttpClient client = InstrumentedOkHttpClients.create(registry, "service-name", rawClient);
-
-    String baseName = OkHttpClient.class.getName() + ".service-name";
+    OkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
 
     assertThat(registry.getMeters()
-        .get(baseName + ".network-requests-submitted")
+        .get(OkHttpClient.class.getName() + ".network-requests-submitted")
         .getCount())
         .isEqualTo(0);
     assertThat(registry.getMeters()
-        .get(baseName + ".network-requests-completed")
+        .get(OkHttpClient.class.getName() + ".network-requests-completed")
         .getCount())
         .isEqualTo(0);
 
@@ -180,18 +167,31 @@ public final class InstrumentedOkHttpClientTest {
     client.newCall(req2).enqueue(new TestCallback());
 
     assertThat(registry.getMeters()
-        .get(baseName + ".network-requests-submitted")
+        .get(OkHttpClient.class.getName() + ".network-requests-submitted")
         .getCount())
         .isEqualTo(2);
     assertThat(registry.getMeters()
-        .get(baseName + ".network-requests-completed")
+        .get(OkHttpClient.class.getName() + ".network-requests-completed")
         .getCount())
         .isEqualTo(2);
   }
 
+  @Test public void providedNameUsedInMetricId() {
+    String randomMetric = "network-requests-submitted";
+    assertThat(registry.getMeters()).isEmpty();
+
+    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(registry, rawClient, null);
+    String generatedId = client.metricId(randomMetric);
+    assertThat(registry.getMeters().get(generatedId)).isNotNull();
+
+    client = new InstrumentedOkHttpClient(registry, rawClient, "custom");
+    generatedId = client.metricId(randomMetric);
+    assertThat(registry.getMeters().get(generatedId)).isNotNull();
+  }
+
   @Test public void equality() throws Exception {
-    InstrumentedOkHttpClient clientA = new InstrumentedOkHttpClient(mockRegistry, "service-name", rawClient);
-    InstrumentedOkHttpClient clientB = new InstrumentedOkHttpClient(mockRegistry, "service-name", rawClient);
+    InstrumentedOkHttpClient clientA = new InstrumentedOkHttpClient(mockRegistry, rawClient, null);
+    InstrumentedOkHttpClient clientB = new InstrumentedOkHttpClient(mockRegistry, rawClient, null);
 
     assertThat(clientA).isEqualTo(clientB);
     assertThat(clientA).isEqualTo(rawClient);
@@ -199,14 +199,8 @@ public final class InstrumentedOkHttpClientTest {
   }
 
   @Test public void stringRepresentation() throws Exception {
-    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(mockRegistry, "service-name", rawClient);
+    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(mockRegistry, rawClient, null);
     assertThat(client.toString()).isEqualTo(rawClient.toString());
-  }
-
-  @Test public void testNameGeneration() {
-    InstrumentedOkHttpClient client = new InstrumentedOkHttpClient(mockRegistry, "serviceA-client", rawClient);
-    String generatedName = client.registryName("cache-hit");
-    assertThat(generatedName).isEqualTo("com.squareup.okhttp.OkHttpClient.serviceA-client.cache-hit");
   }
 
   /**

--- a/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientsTest.java
+++ b/metrics-okhttp/src/test/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClientsTest.java
@@ -17,7 +17,6 @@ package com.raskasa.metrics.okhttp;
 
 import com.codahale.metrics.MetricRegistry;
 import com.squareup.okhttp.OkHttpClient;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,15 +26,11 @@ import static org.mockito.Mockito.mock;
 public final class InstrumentedOkHttpClientsTest {
   private MetricRegistry registry;
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
     registry = mock(MetricRegistry.class);
   }
 
-  @After public void tearDown() throws Exception {
-    registry = null;
-  }
-
-  @Test public void createWithoutClient() throws Exception {
+  @Test public void instrumentDefaultClient() {
     OkHttpClient client = InstrumentedOkHttpClients.create(registry);
 
     // The connection, read, and write timeouts are the only configurations applied by default.
@@ -44,28 +39,46 @@ public final class InstrumentedOkHttpClientsTest {
     assertThat(client.getWriteTimeout()).isEqualTo(10_000);
   }
 
-  @Test public void createWithClient() throws Exception {
-    OkHttpClient rawClient = new OkHttpClient();
-    OkHttpClient client = InstrumentedOkHttpClients.create(registry, "service-name", rawClient);
+  @Test public void instrumentAndNameDefaultClient() {
+    OkHttpClient client = InstrumentedOkHttpClients.create(registry, "custom");
 
-    assertThat(client.getDispatcher()).isEqualTo(rawClient.getDispatcher());
-    assertThat(client.getProxy()).isEqualTo(rawClient.getProxy());
-    assertThat(client.getProtocols()).isEqualTo(rawClient.getProtocols());
-    assertThat(client.getConnectionSpecs()).isEqualTo(rawClient.getConnectionSpecs());
-    assertThat(client.getProxySelector()).isEqualTo(rawClient.getProxySelector());
-    assertThat(client.getCookieHandler()).isEqualTo(rawClient.getCookieHandler());
-    assertThat(client.getCache()).isEqualTo(rawClient.getCache());
-    assertThat(client.getSocketFactory()).isEqualTo(rawClient.getSocketFactory());
-    assertThat(client.getSslSocketFactory()).isEqualTo(rawClient.getSslSocketFactory());
-    assertThat(client.getHostnameVerifier()).isEqualTo(rawClient.getHostnameVerifier());
-    assertThat(client.getCertificatePinner()).isEqualTo(rawClient.getCertificatePinner());
-    assertThat(client.getAuthenticator()).isEqualTo(rawClient.getAuthenticator());
-    assertThat(client.getConnectionPool()).isEqualTo(rawClient.getConnectionPool());
-    assertThat(client.getFollowSslRedirects()).isEqualTo(rawClient.getFollowSslRedirects());
-    assertThat(client.getFollowRedirects()).isEqualTo(rawClient.getFollowRedirects());
-    assertThat(client.getRetryOnConnectionFailure()).isEqualTo(rawClient.getRetryOnConnectionFailure());
-    assertThat(client.getConnectTimeout()).isEqualTo(rawClient.getConnectTimeout());
-    assertThat(client.getReadTimeout()).isEqualTo(rawClient.getReadTimeout());
-    assertThat(client.getWriteTimeout()).isEqualTo(rawClient.getWriteTimeout());
+    // The connection, read, and write timeouts are the only configurations applied by default.
+    assertThat(client.getConnectTimeout()).isEqualTo(10_000);
+    assertThat(client.getReadTimeout()).isEqualTo(10_000);
+    assertThat(client.getWriteTimeout()).isEqualTo(10_000);
+  }
+
+  @Test public void instrumentProvidedClient() {
+    OkHttpClient rawClient = new OkHttpClient();
+    OkHttpClient client = InstrumentedOkHttpClients.create(registry, rawClient);
+    assertThatClientsAreEqual(client, rawClient);
+  }
+
+  @Test public void instrumentAndNameProvidedClient() {
+    OkHttpClient rawClient = new OkHttpClient();
+    OkHttpClient client = InstrumentedOkHttpClients.create(registry, rawClient, "custom");
+    assertThatClientsAreEqual(client, rawClient);
+  }
+
+  private void assertThatClientsAreEqual(OkHttpClient clientA, OkHttpClient clientB) {
+    assertThat(clientA.getDispatcher()).isEqualTo(clientB.getDispatcher());
+    assertThat(clientA.getProxy()).isEqualTo(clientB.getProxy());
+    assertThat(clientA.getProtocols()).isEqualTo(clientB.getProtocols());
+    assertThat(clientA.getConnectionSpecs()).isEqualTo(clientB.getConnectionSpecs());
+    assertThat(clientA.getProxySelector()).isEqualTo(clientB.getProxySelector());
+    assertThat(clientA.getCookieHandler()).isEqualTo(clientB.getCookieHandler());
+    assertThat(clientA.getCache()).isEqualTo(clientB.getCache());
+    assertThat(clientA.getSocketFactory()).isEqualTo(clientB.getSocketFactory());
+    assertThat(clientA.getSslSocketFactory()).isEqualTo(clientB.getSslSocketFactory());
+    assertThat(clientA.getHostnameVerifier()).isEqualTo(clientB.getHostnameVerifier());
+    assertThat(clientA.getCertificatePinner()).isEqualTo(clientB.getCertificatePinner());
+    assertThat(clientA.getAuthenticator()).isEqualTo(clientB.getAuthenticator());
+    assertThat(clientA.getConnectionPool()).isEqualTo(clientB.getConnectionPool());
+    assertThat(clientA.getFollowSslRedirects()).isEqualTo(clientB.getFollowSslRedirects());
+    assertThat(clientA.getFollowRedirects()).isEqualTo(clientB.getFollowRedirects());
+    assertThat(clientA.getRetryOnConnectionFailure()).isEqualTo(clientB.getRetryOnConnectionFailure());
+    assertThat(clientA.getConnectTimeout()).isEqualTo(clientB.getConnectTimeout());
+    assertThat(clientA.getReadTimeout()).isEqualTo(clientB.getReadTimeout());
+    assertThat(clientA.getWriteTimeout()).isEqualTo(clientB.getWriteTimeout());
   }
 }


### PR DESCRIPTION
By default, we don't want an instrumented client to have a default name.  Naming of instrumented clients is more of a convenience for those that use multiple OkHttpClients per application.