### PR TITLE
Update OkHttp dependency to 2.7

### DIFF
--- a/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClient.java
+++ b/metrics-okhttp/src/main/java/com/raskasa/metrics/okhttp/InstrumentedOkHttpClient.java
@@ -25,6 +25,7 @@ import com.squareup.okhttp.CertificatePinner;
 import com.squareup.okhttp.ConnectionPool;
 import com.squareup.okhttp.ConnectionSpec;
 import com.squareup.okhttp.Dispatcher;
+import com.squareup.okhttp.Dns;
 import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Protocol;
@@ -210,6 +211,14 @@ final class InstrumentedOkHttpClient extends OkHttpClient {
 
   @Override public Cache getCache() {
     return rawClient.getCache();
+  }
+
+  @Override public OkHttpClient setDns(Dns dns) {
+    return rawClient.setDns(dns);
+  }
+
+  @Override public Dns getDns() {
+    return rawClient.getDns();
   }
 
   @Override public OkHttpClient setSocketFactory(SocketFactory socketFactory) {

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <java.version>1.7</java.version>
     <metrics.version>3.1.2</metrics.version>
     <mockito.version>1.10.19</mockito.version>
-    <okhttp.version>2.6.0</okhttp.version>
+    <okhttp.version>2.7.0</okhttp.version>
 
     <!-- Test dependencies -->
     <assertj.version>2.2.0</assertj.version>


### PR DESCRIPTION
2.7 adds two new API methods on the OkHttpClient that need to be forwarded properly.